### PR TITLE
Adding ability to group by angular expressions

### DIFF
--- a/src/ngGroup.js
+++ b/src/ngGroup.js
@@ -5,21 +5,7 @@
 (function filters() {
   'use strict';
 
-
-  function getProperty(value, propName) {
-    var property = value[propName];
-    var propValue;
-    if (typeof(property) === 'function') {
-      propValue = property.call(value);
-    } else {
-      propValue = property;
-    }
-    return propValue;
-  }
-
-
   angular.module('ng.group', [])
-
 
   /*
    * Group the input objects by a named field: e.g.
@@ -34,7 +20,7 @@
    * return the same objects, so that ng-repeat's digest cycle will correctly
    * recognise the output has not changed.
    */
-  .filter('groupBy', function () {
+  .filter('groupBy', ['$parse', function ($parse) {
     var poolCache = {};
     poolCache.poolFor = function poolFor(memoKey, groupField) {
       var groupPool;
@@ -63,7 +49,7 @@
       this.poolGen = 0;
     }
     GroupPool.prototype.addItem = function addItem(item) {
-      var groupValue = getProperty(item, this.groupField);
+      var groupValue = $parse(this.groupField)(item);
       var group;
       if (this.hasOwnProperty(groupValue)) group = this[groupValue];
       if (group === undefined) {
@@ -117,5 +103,5 @@
 
       return filtered;
     };
-  });
+  }]);
 })();

--- a/test/ngGroupSpec.js
+++ b/test/ngGroupSpec.js
@@ -120,7 +120,7 @@ describe('ng.group', function () {
       });
     });
 
-    it('should work with object methods too', function () {
+    it('should work with object methods', function () {
       function Person(data) {
         for (var k in data) this[k] = data[k];
       }
@@ -136,19 +136,41 @@ describe('ng.group', function () {
       ].map(function (data) { return new Person(data); });
 
       function town(name) {
-        return jasmine.objectContaining({uptown: name});
+        return jasmine.objectContaining({'uptown()': name});
       }
 
-      var filtered = groupByFilter(people, 'uptown');
+      var filtered = groupByFilter(people, 'uptown()');
 
       expect(filtered).toContain(town('LONDON'));
       var LONDONers = filtered.filter(function (townsAndPeople) {
-        return townsAndPeople.uptown === 'LONDON';
+        return townsAndPeople['uptown()'] === 'LONDON';
       })[0];
       expect(LONDONers.items).toContain(personNamed('Sam'));
       expect(LONDONers.items).toContain(personNamed('Alex'));
     });
-
+    
+    it('should work with nested fields', function () {
+      var people = [
+        {name: 'Bob', homeAddress: { town: 'New York City'} },
+        {name: 'Sam', homeAddress: { town: 'London'} },
+        {name: 'Alice', homeAddress: { town: 'New York City'} },
+        {name: 'Alex', homeAddress: { town: 'London'} },
+        {name: 'Dave', homeAddress: { town: 'San Francisco'} }
+      ];
+      
+      function town(name) {
+        return jasmine.objectContaining({'homeAddress.town': name});
+      }
+      
+      var filtered = groupByFilter(people, 'homeAddress.town');
+      
+      expect(filtered).toContain(town('London'));
+      var Londoners = filtered.filter(function (townsAndPeople) {
+        return townsAndPeople['homeAddress.town'] === 'London';
+      })[0];
+      expect(Londoners.items).toContain(personNamed('Sam'));
+      expect(Londoners.items).toContain(personNamed('Alex'));
+    });
 
     describe('caching', function () {
       var men = [


### PR DESCRIPTION
I think it would be useful to be able to group on nested fields, as can be done with `orderBy`, such as

``` html
<div ng-repeat="placePeople in people | groupBy:'homeAddress.town':'peopleByHome'">
<h2>{{placePeople['homeAddress.town']}}</h2>
```

These changes make use of `$parse` to achieve this.

Note it is a backwards incompatible change in terms of grouping by functions, as now you can't leave off the braces in the expression, i.e.

``` html
<div ng-repeat="placePeople in people | groupBy:'uptown()':'peopleByHome'">
<h2>{{placePeople['uptown()']}}</h2>
```

So probably would need a version bump.

Given these changes, I'd be tempted to make a further change (which is not included here) to use a fixed name for the group key, rather than the expression, as the above would probably look neater with

``` html
<h2>{{placePeople.groupKey}}</h2>
```

Hope this is useful. Let me know any thoughts, thanks.
